### PR TITLE
Restrict pytest to v5.2.0 or above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_install:
   - sudo apt-get update; sudo apt-get install -y postgresql-11 postgresql-client-11
   - sudo cp /etc/postgresql/{9.6,11}/main/pg_hba.conf
   - sudo service postgresql restart 11
-  - pip uninstall pytest && pip install pytest
+  - pip uninstall -y pytest && pip install pytest
 
 install:
   - pip install .


### PR DESCRIPTION
Lower versions may have problems with the 'attrs' package