### PR TITLE
Correctly display human readable distance and duration

### DIFF
--- a/flaskr/templates/compare_locations.html
+++ b/flaskr/templates/compare_locations.html
@@ -107,8 +107,8 @@
                             {'data_value': row.average_rent, 'content': row.average_rent},
                             {'data_value': row.rent_under_250, 'content': row.rent_under_250},
                             {'data_value': row.rent_250_to_500, 'content': row.rent_250_to_500},
-                            {'data_value': row.distance_to_london, 'content': row.distance_to_london},
-                            {'data_value': row.duration_to_london, 'content': row.duration_to_london},
+                            {'data_value': row.distance_to_london, 'content': row.distance_to_london_text},
+                            {'data_value': row.duration_to_london, 'content': row.duration_to_london_text},
                             {'data_value': row.score, 'content': row.score},
                         ] %}
                         {% for cell in row_data %}


### PR DESCRIPTION
For distance to london and duration to london display human readable values instead of raw data (i.e. number of metres or number of seconds